### PR TITLE
Fix dropping of values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,22 @@
 'use strict';
 
+function collapseArgs(func) {
+    return function() {
+        var args = Array.prototype.slice.call(arguments);
+        if (args.length === 0) {
+            func();
+        } else if (args.length === 1) {
+            func(args[0]);
+        } else {
+            func(args);
+        }
+    };
+}
+
 module.exports = function(deferred) {
     return new Promise(function(resolve, reject) {
-        deferred.done(resolve).fail(reject);
+        deferred
+            .done(collapseArgs(resolve))
+            .fail(collapseArgs(reject));
     });
 };

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var test = require('tape'),
     $ = require('jquery-deferred'),
     deferredAsPromise = require('./');
 
-test('$.Deferred as a promise', function(t) {
+test('$.Deferred as a promise - no args', function(t) {
     t.plan(2);
 
     var deferredSuccess = $.Deferred();
@@ -12,7 +12,7 @@ test('$.Deferred as a promise', function(t) {
 
     deferredAsPromise(deferredSuccess)
         .then(function(result) {
-            t.equal(result, 'success');
+            t.equal(result, undefined, 'resolves with undefined');
         })
         .catch(function() {
             t.fail('should resolve');
@@ -23,9 +23,63 @@ test('$.Deferred as a promise', function(t) {
             t.fail('should reject');
         })
         .catch(function(error) {
-            t.equal(error, 'error');
+            t.equal(error, undefined, 'rejects with undefined');
+        });
+
+    deferredSuccess.resolve();
+    deferredError.reject();
+});
+
+test('$.Deferred as a promise - 1 arg', function(t) {
+    t.plan(2);
+
+    var deferredSuccess = $.Deferred();
+    var deferredError = $.Deferred();
+
+    deferredAsPromise(deferredSuccess)
+        .then(function(result) {
+            t.equal(result, 'success', 'resolves with value');
+        })
+        .catch(function() {
+            t.fail('should resolve');
+        });
+
+    deferredAsPromise(deferredError)
+        .then(function() {
+            t.fail('should reject');
+        })
+        .catch(function(error) {
+            t.equal(error, 'error', 'rejects with error');
         });
 
     deferredSuccess.resolve('success');
     deferredError.reject('error');
+});
+
+test('$.Deferred as a promise - multiple args', function(t) {
+    t.plan(2);
+
+    var deferredSuccess = $.Deferred();
+    var deferredError = $.Deferred();
+
+    deferredAsPromise(deferredSuccess)
+        .then(function(result) {
+            t.deepEqual(result, ['success1', 'success2'],
+                'resolves with array of values');
+        })
+        .catch(function() {
+            t.fail('should resolve');
+        });
+
+    deferredAsPromise(deferredError)
+        .then(function() {
+            t.fail('should reject');
+        })
+        .catch(function(error) {
+            t.deepEqual(error, ['error1', 'error2'],
+                'rejects with array of errors');
+        });
+
+    deferredSuccess.resolve('success1', 'success2');
+    deferredError.reject('error1', 'error2');
 });


### PR DESCRIPTION
When a deferred is resolved/rejected with multiple values,
resolve/reject the native promise with an array of those values so as
not to drop information.

Fixes #1